### PR TITLE
Add configuration for ECR build cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ This GitHub Action runs the following steps:
 ✔️ **Multi-tag and Multi-platform Docker Builds**  
 Build images for `linux/amd64`, `linux/arm64`, and more, with multiple tags.
 
-✔️ **Docker Layer Caching**  
+✔️ **Docker Layer Caching**
 Faster builds using GitHub Actions cache.
+
+✔️ **ECR Build Cache Support**
+Push and reuse build layers stored alongside your image in Amazon ECR.
 
 ✔️ **Build Args, Target Stage & Dockerfile Path Support**  
 Flexible customization for various Docker build needs.
@@ -53,7 +56,9 @@ Flexible customization for various Docker build needs.
 | `build_args`         | Comma-separated list of build arguments                      | ❌       | `""`           |
 | `push`               | Whether to push the Docker image to ECR                      | ❌       | `true`         |
 | `force_ecr_login`    | Force a new login to ECR                                     | ❌       | `false`        |
-| `docker_layer_cache` | Use Docker layer caching                                     | ❌       | `true`         |
+| `docker_layer_cache` | Use Docker layer caching (GitHub Actions cache)              | ❌       | `true`         |
+| `enable_buildcache`  | Use an ECR registry cache for build layers                   | ❌       | `false`        |
+| `buildcache_tag_name`| Tag used when storing build cache layers in ECR              | ❌       | `buildcache`   |
 | `target`             | Docker build target stage                                    | ❌       | `""`           |
 | `dockerfile_path`    | Path to the Dockerfile                                       | ❌       | `Dockerfile`   |
 | `platforms`          | Target platforms for Docker build                            | ❌       | `linux/amd64`  |
@@ -86,6 +91,8 @@ jobs:
           image_name: "my-app"
           tag: "latest,sha-${{ github.sha }}"
           build_args: "ENV=production,VERSION=${{ github.sha }}"
+          enable_buildcache: "true"
+          buildcache_tag_name: "buildcache"
           aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
           aws_region: ${{ secrets.AWS_DEFAULT_REGION }}
 
@@ -93,3 +100,4 @@ jobs:
 
 - This action uses `aws-actions/amazon-ecr-login` and `docker/build-push-action` internally.
 - Make sure the IAM role (default: `github_services`) has permission to interact with ECR.
+- When using the ECR build cache, either enable `push` or set `force_ecr_login: true` so the workflow can authenticate with ECR.

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,14 @@ inputs:
     description: "Whether to use docker caching"
     required: false
     default: "true"
+  enable_buildcache:
+    description: "Enable using an ECR registry build cache"
+    required: false
+    default: "false"
+  buildcache_tag_name:
+    description: "Tag to use when storing build cache layers"
+    required: false
+    default: "buildcache"
   target:
     description: "Sets the target stage to build"
     required: false
@@ -67,14 +75,14 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      if: ${{ inputs.push == 'true' || inputs.force_ecr_login == 'true' }}
+      if: ${{ inputs.push == 'true' || inputs.force_ecr_login == 'true' || inputs.enable_buildcache == 'true' }}
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: "arn:aws:iam::${{ inputs.aws_account_id }}:role/${{ inputs.aws_role}}"
         aws-region: ${{ inputs.aws_region }}
 
     - name: Login to Amazon ECR
-      if: ${{ inputs.push == 'true' || inputs.force_ecr_login == 'true' }}
+      if: ${{ inputs.push == 'true' || inputs.force_ecr_login == 'true' || inputs.enable_buildcache == 'true' }}
       id: login_ecr
       uses: aws-actions/amazon-ecr-login@v2
 
@@ -98,7 +106,7 @@ runs:
         echo "tags=$IMAGES" >> "$GITHUB_OUTPUT"
 
     - name: Ensure ECR repository exists
-      if: ${{ inputs.push == 'true' }}
+      if: ${{ inputs.push == 'true' || inputs.enable_buildcache == 'true' }}
       shell: bash
       run: |
         set -e
@@ -113,6 +121,41 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Prepare cache configuration
+      id: prepare_cache
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        cache_from=""
+        cache_to=""
+
+        if [ "${{ inputs.docker_layer_cache }}" = "true" ]; then
+          cache_from="type=gha"
+          cache_to="type=gha,mode=max"
+        fi
+
+        if [ "${{ inputs.enable_buildcache }}" = "true" ]; then
+          registry="${{ inputs.aws_account_id }}.dkr.ecr.${{ inputs.aws_region }}.amazonaws.com"
+          cache_from_registry="type=registry,ref=${registry}/${{ inputs.image_name }}:${{ inputs.buildcache_tag_name }}"
+          cache_to_registry="type=registry,ref=${registry}/${{ inputs.image_name }}:${{ inputs.buildcache_tag_name }},mode=max"
+
+          if [ -n "$cache_from" ]; then
+            cache_from="${cache_from}"$'\n'"${cache_from_registry}"
+          else
+            cache_from="$cache_from_registry"
+          fi
+
+          if [ -n "$cache_to" ]; then
+            cache_to="${cache_to}"$'\n'"${cache_to_registry}"
+          else
+            cache_to="$cache_to_registry"
+          fi
+        fi
+
+        printf 'cache_from<<EOF\n%s\nEOF\n' "$cache_from" >> "$GITHUB_OUTPUT"
+        printf 'cache_to<<EOF\n%s\nEOF\n' "$cache_to" >> "$GITHUB_OUTPUT"
+
     - name: Build (and optionally push) Docker image
       uses: docker/build-push-action@v6.18.0
       with:
@@ -125,5 +168,5 @@ runs:
         build-args: ${{ inputs.build_args }}
         file: ${{ inputs.dockerfile_path }}
         platforms: ${{ inputs.platforms }}
-        cache-from: ${{ inputs.docker_layer_cache == 'true' && 'type=gha' || '' }}
-        cache-to: ${{ inputs.docker_layer_cache == 'true' && 'type=gha,mode=max' || '' }}
+        cache-from: ${{ steps.prepare_cache.outputs.cache_from }}
+        cache-to: ${{ steps.prepare_cache.outputs.cache_to }}


### PR DESCRIPTION
## Summary
- add inputs to enable publishing and consuming build cache layers from ECR
- ensure AWS authentication and repository creation run when the registry cache is used
- document the new options and example usage in the README

## Testing
- not run